### PR TITLE
feat: add sablier & k8s on-prem gitlab repo & slides

### DIFF
--- a/2025.md
+++ b/2025.md
@@ -13,7 +13,8 @@
 ## Jeudi
 
 ### 3 ans de Kubernetes on-premises : le bilan sans filtre
-* [Slides](https://lgatellier.gitlab.io/talk-rex-3-ans-k8s/#kubernetes-cest-quoi-)
+* [Slides](https://lgatellier.gitlab.io/talk-rex-3-ans-k8s/)
+* [Dépôt GitLab de la présentation](https://gitlab.com/lgatellier/talk-rex-3-ans-k8s/)
 
 ### OpenRewrite: Refactoring as code
 
@@ -35,6 +36,11 @@
 ### CQRS / ES : Nos heuristiques après plusieurs années de production
 
 * [Article de blog](https://romaintrm.github.io/posts/2024-11-26/) regroupant abstract, replays et slides.  
+
+### Sablier : Démarrez et arrêtez automatiquement vos applications peu utilisées
+
+* [Slides](https://lgatellier.gitlab.io/talk-sablier/)
+* [Dépôt GitLab de la présentation & démo](https://gitlab.com/lgatellier/talk-sablier/)
 
 ### Les Méta-Lois, vous n'y échapperez pas !
 


### PR DESCRIPTION
This PR adds/fixes slides URLs and GitLab repo URLs for two talks :
- 3 ans de Kubernetes on-premises : le bilan sans filtre
- Sablier : Démarrez et arrêtez automatiquement vos applications peu utilisées